### PR TITLE
DO NOT MERGE Prevent integer wrap around for malloc size when creatin…

### DIFF
--- a/src/core/SkRegionPriv.h
+++ b/src/core/SkRegionPriv.h
@@ -65,7 +65,10 @@ public:
 
         SkASSERT(count >= SkRegion::kRectRegionRuns);
 
-        RunHead* head = (RunHead*)sk_malloc_throw(sizeof(RunHead) + count * sizeof(RunType));
+        const int64_t size = sk_64_mul(count, sizeof(RunType)) + sizeof(RunHead);
+        if (count < 0 || !sk_64_isS32(size)) { SK_CRASH(); }
+
+        RunHead* head = (RunHead*)sk_malloc_throw(size);
         head->fRefCnt = 1;
         head->fRunCount = count;
         // these must be filled in later, otherwise we will be invalid


### PR DESCRIPTION
…g a SkRegion

Review URL: https://codereview.chromium.org/1143603003

Uses sk_64_mul instead of Sk64

bug:20883006
(cherry picked from commit 181f49c7acb67ad009f6deceb3b5cc0a45220ab4)

Change-Id: If93c6b957ea2f31b882cc272268700e415f724c5
